### PR TITLE
simplify address determination

### DIFF
--- a/update-plex-ipv6-access-url.sh
+++ b/update-plex-ipv6-access-url.sh
@@ -38,7 +38,7 @@ expand_ipv6() {
 }
 
 # Get IPv6 address of given interface (command adapted from: https://superuser.com/a/1057290)
-IPv6=`/sbin/ip -6 addr show dev "$1" | grep inet6 | awk -F '[ \t]+|/' '{print $3}' | grep -v ^::1 | grep -v ^fe80`
+IPv6=`/sbin/ip -6 addr show dev "$1" scope global | grep inet6 | awk -F '[ \t]+|/' '{print $3}'`
 if [ -n "$IPv6" ]; then
 	echo "Got IPv6 address: $IPv6"
 	# Format IPv6 for Plex (replace : with -)


### PR DESCRIPTION
tested on centos 7.9.2009 and ubuntu 20.04

don't need to exclude link-local and localhost with `scope global`

```
ubuntu@knode4:~$ /sbin/ip -6 addr show dev lo scope global
ubuntu@knode4:~$ /sbin/ip -6 addr show dev eth0 scope global
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    inet6 fd6c:e525:e3d4:2722:dea6:32ff:fe50:743b/64 scope global dynamic mngtmpaddr noprefixroute 
       valid_lft 2591954sec preferred_lft 604754sec
ubuntu@knode4:~$ 
```

however if you add additional routable addresses to `lo` it should be included:
```
ubuntu@knode4:~$ sudo ip -6 addr add fd6c:e525::1/128 dev lo
ubuntu@knode4:~$ /sbin/ip -6 addr show dev lo scope global
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    inet6 fd6c:e525::1/128 scope global 
       valid_lft forever preferred_lft forever
```
